### PR TITLE
Patch reflection channel getter at PlayerJoinEvent (1.20.2)

### DIFF
--- a/src/main/java/tech/sbdevelopment/mapreflectionapi/listeners/PacketListener.java
+++ b/src/main/java/tech/sbdevelopment/mapreflectionapi/listeners/PacketListener.java
@@ -144,7 +144,13 @@ public class PacketListener implements Listener {
     private Channel getChannel(Player player) {
         Object playerHandle = getHandle(player);
         Object playerConnection = getDeclaredField(playerHandle, supports(20) ? "c" : supports(17) ? "b" : "playerConnection"); //1.20 = c, 1.17-1.19 = b, 1.16 = playerConnection
-        Object networkManager = getDeclaredField(playerConnection, supports(19, 3) ? "h" : supports(19) ? "b" : supports(17) ? "a" : "networkManager"); //1.20 & 1.19.4 = h, >= 1.19.3 = b, 1.18 = a, 1.16 = networkManager
+
+        Object networkManager;
+        if (supports(20, 2))
+            networkManager = getSuperDeclaredField(playerConnection, "c"); //1.20.2 = c
+        else
+            networkManager = getDeclaredField(playerConnection, supports(19, 3) ? "h" : supports(19) ? "b" : supports(17) ? "a" : "networkManager"); //1.20 & 1.19.4 = h, >= 1.19.3 = b, 1.18 = a, 1.16 = networkManager
+
         return (Channel) getDeclaredField(networkManager, supports(20, 2) ? "n" : supports(18) ? "m" : supports(17) ? "k" : "channel"); //1.20.2 = n, 1.20(.1), 1.19 & 1.18 = m, 1.17 = k, 1.16 = channel
     }
 

--- a/src/main/java/tech/sbdevelopment/mapreflectionapi/utils/ReflectionUtil.java
+++ b/src/main/java/tech/sbdevelopment/mapreflectionapi/utils/ReflectionUtil.java
@@ -299,6 +299,26 @@ public class ReflectionUtil {
         }
     }
 
+    @Nullable
+    public static Object getSuperDeclaredField(Object object, String field) {
+        try {
+            String cacheKey = "SuperDeclaredField:" + object.getClass().getSuperclass().getName() + ":" + field;
+
+            if (fieldCache.containsKey(cacheKey)) {
+                Field cachedField = fieldCache.get(cacheKey);
+                return cachedField.get(object);
+            } else {
+                Field f = object.getClass().getSuperclass().getDeclaredField(field);
+                f.setAccessible(true);
+                fieldCache.put(cacheKey, f);
+                return f.get(object);
+            }
+        } catch (NoSuchFieldException | IllegalAccessException ex) {
+            ex.printStackTrace();
+            return null;
+        }
+    }
+
     public static void setDeclaredField(Object object, String field, Object value) {
         try {
             String cacheKey = "DeclaredField:" + object.getClass().getName() + ":" + field;


### PR DESCRIPTION
Now the networkManager doesn't exists anymore in Connection object, it's in extends class of it, so I got the field with the getSuperclass() function of JavaReflection.
I've tested in 1.20.2 and 1.20.1 to be sure that the plugin still works in other versions.

Have a nice day 💯 